### PR TITLE
Add missing headers, Pin GSL version at v2.0.0, Fix wchar_t signedness, Use Catch2/devel branch

### DIFF
--- a/Chapter03/scratchpad.cpp
+++ b/Chapter03/scratchpad.cpp
@@ -116,33 +116,19 @@ int main(void)
 
 int main(void)
 {
-    auto num_bytes_signed = sizeof(signed wchar_t);
-    auto min_signed = std::numeric_limits<signed wchar_t>().min();
-    auto max_signed = std::numeric_limits<signed wchar_t>().max();
+    auto num_bytes = sizeof(wchar_t);
+    auto min = std::numeric_limits<wchar_t>().min();
+    auto max = std::numeric_limits<wchar_t>().max();
 
-    auto num_bytes_unsigned = sizeof(unsigned wchar_t);
-    auto min_unsigned = std::numeric_limits<unsigned wchar_t>().min();
-    auto max_unsigned = std::numeric_limits<unsigned wchar_t>().max();
-
-    std::cout << "num bytes (signed): " << num_bytes_signed << '\n';
-    std::cout << "min value (signed): " << +min_signed << '\n';
-    std::cout << "max value (signed): " << +max_signed << '\n';
-
-    std::cout << '\n';
-
-    std::cout << "num bytes (unsigned): " << num_bytes_unsigned << '\n';
-    std::cout << "min value (unsigned): " << +min_unsigned << '\n';
-    std::cout << "max value (unsigned): " << +max_unsigned << '\n';
+    std::cout << "num bytes: " << num_bytes << '\n';
+    std::cout << "min value: " << +min << '\n';
+    std::cout << "max value: " << +max << '\n';
 }
 
 // > g++ scratchpad.cpp; ./a.out
-// num bytes (signed): 4
-// min value (signed): -2147483648
-// max value (signed): 2147483647
-
-// num bytes (unsigned): 4
-// min value (unsigned): 0
-// max value (unsigned): 4294967295
+// num bytes: 4
+// min value: -2147483648
+// max value: 2147483647
 
 #endif
 

--- a/Chapter03/scratchpad.cpp
+++ b/Chapter03/scratchpad.cpp
@@ -75,6 +75,7 @@ int main(void)
 #if SNIPPET04
 
 #include <iostream>
+#include <limits>
 
 int main(void)
 {
@@ -111,6 +112,7 @@ int main(void)
 #if SNIPPET05
 
 #include <iostream>
+#include <limits>
 
 int main(void)
 {
@@ -147,6 +149,7 @@ int main(void)
 #if SNIPPET06
 
 #include <iostream>
+#include <limits>
 
 int main(void)
 {
@@ -202,6 +205,7 @@ int main(void)
 #if SNIPPET08
 
 #include <iostream>
+#include <limits>
 
 int main(void)
 {
@@ -238,6 +242,7 @@ int main(void)
 #if SNIPPET09
 
 #include <iostream>
+#include <limits>
 
 int main(void)
 {
@@ -274,6 +279,7 @@ int main(void)
 #if SNIPPET10
 
 #include <iostream>
+#include <limits>
 
 int main(void)
 {
@@ -296,6 +302,7 @@ int main(void)
 #if SNIPPET11
 
 #include <iostream>
+#include <limits>
 
 int main(void)
 {
@@ -318,6 +325,7 @@ int main(void)
 #if SNIPPET12
 
 #include <iostream>
+#include <limits>
 
 int main(void)
 {
@@ -340,6 +348,7 @@ int main(void)
 #if SNIPPET13
 
 #include <iostream>
+#include <limits>
 
 int main(void)
 {

--- a/Chapter04/CMakeLists.txt
+++ b/Chapter04/CMakeLists.txt
@@ -43,6 +43,7 @@ list(APPEND GSL_CMAKE_ARGS
 ExternalProject_Add(
     gsl
     GIT_REPOSITORY https://github.com/Microsoft/GSL.git
+    GIT_TAG v2.0.0
     GIT_SHALLOW 1
     CMAKE_ARGS ${GSL_CMAKE_ARGS}
     PREFIX ${CMAKE_BINARY_DIR}/external/gsl/prefix

--- a/Chapter06/CMakeLists.txt
+++ b/Chapter06/CMakeLists.txt
@@ -43,6 +43,7 @@ list(APPEND GSL_CMAKE_ARGS
 ExternalProject_Add(
     gsl
     GIT_REPOSITORY https://github.com/Microsoft/GSL.git
+    GIT_TAG v2.0.0
     GIT_SHALLOW 1
     CMAKE_ARGS ${GSL_CMAKE_ARGS}
     PREFIX ${CMAKE_BINARY_DIR}/external/gsl/prefix

--- a/Chapter07/scratchpad.cpp
+++ b/Chapter07/scratchpad.cpp
@@ -1036,6 +1036,7 @@ int main()
 
 #include <thread>
 #include <iostream>
+#include <memory>
 
 class myclass
 {

--- a/Chapter08/CMakeLists.txt
+++ b/Chapter08/CMakeLists.txt
@@ -43,6 +43,7 @@ list(APPEND GSL_CMAKE_ARGS
 ExternalProject_Add(
     gsl
     GIT_REPOSITORY https://github.com/Microsoft/GSL.git
+    GIT_TAG v2.0.0
     GIT_SHALLOW 1
     CMAKE_ARGS ${GSL_CMAKE_ARGS}
     PREFIX ${CMAKE_BINARY_DIR}/external/gsl/prefix

--- a/Chapter09/CMakeLists.txt
+++ b/Chapter09/CMakeLists.txt
@@ -43,6 +43,7 @@ list(APPEND GSL_CMAKE_ARGS
 ExternalProject_Add(
     gsl
     GIT_REPOSITORY https://github.com/Microsoft/GSL.git
+    GIT_TAG v2.0.0
     GIT_SHALLOW 1
     CMAKE_ARGS ${GSL_CMAKE_ARGS}
     PREFIX ${CMAKE_BINARY_DIR}/external/gsl/prefix

--- a/Chapter09/CMakeLists.txt
+++ b/Chapter09/CMakeLists.txt
@@ -67,6 +67,7 @@ list(APPEND CATCH_CMAKE_ARGS
 ExternalProject_Add(
     catch
     GIT_REPOSITORY https://github.com/catchorg/Catch2.git
+    GIT_TAG devel
     GIT_SHALLOW 1
     CMAKE_ARGS ${CATCH_CMAKE_ARGS}
     PREFIX ${CMAKE_BINARY_DIR}/external/catch/prefix

--- a/Chapter10/CMakeLists.txt
+++ b/Chapter10/CMakeLists.txt
@@ -43,6 +43,7 @@ list(APPEND GSL_CMAKE_ARGS
 ExternalProject_Add(
     gsl
     GIT_REPOSITORY https://github.com/Microsoft/GSL.git
+    GIT_TAG v2.0.0
     GIT_SHALLOW 1
     CMAKE_ARGS ${GSL_CMAKE_ARGS}
     PREFIX ${CMAKE_BINARY_DIR}/external/gsl/prefix

--- a/Chapter11/CMakeLists.txt
+++ b/Chapter11/CMakeLists.txt
@@ -43,6 +43,7 @@ list(APPEND GSL_CMAKE_ARGS
 ExternalProject_Add(
     gsl
     GIT_REPOSITORY https://github.com/Microsoft/GSL.git
+    GIT_TAG v2.0.0
     GIT_SHALLOW 1
     CMAKE_ARGS ${GSL_CMAKE_ARGS}
     PREFIX ${CMAKE_BINARY_DIR}/external/gsl/prefix

--- a/Chapter12/CMakeLists.txt
+++ b/Chapter12/CMakeLists.txt
@@ -43,6 +43,7 @@ list(APPEND GSL_CMAKE_ARGS
 ExternalProject_Add(
     gsl
     GIT_REPOSITORY https://github.com/Microsoft/GSL.git
+    GIT_TAG v2.0.0
     GIT_SHALLOW 1
     CMAKE_ARGS ${GSL_CMAKE_ARGS}
     PREFIX ${CMAKE_BINARY_DIR}/external/gsl/prefix

--- a/Chapter12/scratchpad.cpp
+++ b/Chapter12/scratchpad.cpp
@@ -802,6 +802,7 @@ main()
 #if SNIPPET23
 
 #include <shared_mutex>
+#include <mutex>
 #include <thread>
 #include <iostream>
 

--- a/Chapter13/CMakeLists.txt
+++ b/Chapter13/CMakeLists.txt
@@ -43,6 +43,7 @@ list(APPEND GSL_CMAKE_ARGS
 ExternalProject_Add(
     gsl
     GIT_REPOSITORY https://github.com/Microsoft/GSL.git
+    GIT_TAG v2.0.0
     GIT_SHALLOW 1
     CMAKE_ARGS ${GSL_CMAKE_ARGS}
     PREFIX ${CMAKE_BINARY_DIR}/external/gsl/prefix


### PR DESCRIPTION
These changes fix the build on Arch Linux with GCC 12.1.0.

```
* Chapter09: use 'devel' as the default branch for Catch2
* Use microsoft/GSL v2.0.0
  Later versions have API changes that break the build.
* Chapter12/SNIPPET23: add missing header <mutex>
* Chapter07/SNIPPET45: add missing header <memory>
* Chapter03/SNIPPET05: remove signedness from wchar_t
  "signed/unsigned wchar_t" is not a legal type and is rejected with g++
  and clang.
* Chapter03: add missing header <limits>
```

Thank you for writing this book!